### PR TITLE
Add Range support

### DIFF
--- a/benchmark-jmh/src/main/scala/com/github/johnynek/inliner/benchmark/jmh/RangeBenchmarks.scala
+++ b/benchmark-jmh/src/main/scala/com/github/johnynek/inliner/benchmark/jmh/RangeBenchmarks.scala
@@ -1,0 +1,45 @@
+package com.github.johnynek.inliner.benchmark.jmh
+
+import com.github.johnynek.inliner.InlineRange._
+
+import java.util.Random
+import java.util.concurrent.TimeUnit
+import org.openjdk.jmh.annotations._
+import scala.util.{Failure, Success, Try}
+import org.openjdk.jmh.infra.Blackhole
+
+object RangeBenchmarks {
+  val inputRange = (-10 to 10000)
+}
+
+@OutputTimeUnit(TimeUnit.NANOSECONDS)
+@BenchmarkMode(Array(Mode.SingleShotTime))
+@Warmup(batchSize = 10000)
+@Measurement(batchSize = 40000)
+@Fork(value = 1)
+class RangeBenchmarks {
+  import RangeBenchmarks._
+
+  @Benchmark
+  @Measurement(batchSize = 20000)
+  def foreachInline(bh: Blackhole): Unit = {
+    var iter = 20
+    while(iter > 0) {
+      iter -= 1
+      var sum = 0
+      inputRange.inline.foreach(sum += _)
+      bh.consume(sum)
+    }
+  }
+  @Benchmark
+  @Measurement(batchSize = 20000)
+  def foreach(bh: Blackhole): Unit = {
+    var iter = 20
+    while(iter > 0) {
+      iter -= 1
+      var sum = 0
+      inputRange.foreach(sum += _)
+      bh.consume(sum)
+    }
+  }
+}

--- a/core/src/main/scala/com/github/johnynek/inliner/InlineArray.scala
+++ b/core/src/main/scala/com/github/johnynek/inliner/InlineArray.scala
@@ -56,7 +56,7 @@ object InlineArray {
   def findMethod[T](c: Context)(fn: c.Expr[T => Boolean])(implicit T: c.WeakTypeTag[T]): c.Expr[Option[T]] =
     findTree(c)(singleConsArg(c), fn)
 
-  def forall[T](ts: TraversableOnce[T])(fn: T => Boolean): Boolean = macro forallMacro[T]
+  def forall[T](ts: Array[T])(fn: T => Boolean): Boolean = macro forallMacro[T]
 
   private[this] def forallTree[T](c: Context)(ts: c.Tree, fn: c.Expr[T => Boolean]): c.Expr[Boolean] = {
     import c.universe._
@@ -82,13 +82,13 @@ object InlineArray {
     //println(tree)
     c.Expr[Boolean](tree)
   }
-  def forallMacro[T](c: Context)(ts: c.Expr[TraversableOnce[T]])(fn: c.Expr[T => Boolean]): c.Expr[Boolean] =
+  def forallMacro[T](c: Context)(ts: c.Expr[Array[T]])(fn: c.Expr[T => Boolean]): c.Expr[Boolean] =
     forallTree(c)(ts.tree, fn)
 
   def forallMethod[T](c: Context)(fn: c.Expr[T => Boolean]): c.Expr[Boolean] =
     forallTree(c)(singleConsArg(c), fn)
 
-  def foreach[T](ts: TraversableOnce[T])(fn: T => Unit): Unit = macro foreachMacro[T]
+  def foreach[T](ts: Array[T])(fn: T => Unit): Unit = macro foreachMacro[T]
 
   private[this] def foreachTree[T](c: Context)(ts: c.Tree, fn: c.Expr[T => Unit]): c.Expr[Unit] = {
     import c.universe._
@@ -112,13 +112,13 @@ object InlineArray {
     //println(tree)
     c.Expr[Unit](tree)
   }
-  def foreachMacro[T](c: Context)(ts: c.Expr[TraversableOnce[T]])(fn: c.Expr[T => Unit]): c.Expr[Unit] =
+  def foreachMacro[T](c: Context)(ts: c.Expr[Array[T]])(fn: c.Expr[T => Unit]): c.Expr[Unit] =
     foreachTree(c)(ts.tree, fn)
 
   def foreachMethod[T](c: Context)(fn: c.Expr[T => Unit]): c.Expr[Unit] =
     foreachTree(c)(singleConsArg(c), fn)
 
-  def foldLeft[T, U](ts: TraversableOnce[T], init: U)(fn: (U, T) => U): U = macro foldLeftMacro[T, U]
+  def foldLeft[T, U](ts: Array[T], init: U)(fn: (U, T) => U): U = macro foldLeftMacro[T, U]
 
   private[this] def foldLeftTree[T, U](c: Context)(ts: c.Tree, init: c.Expr[U], fn: c.Expr[(U, T) => U]): c.Expr[U] = {
     import c.universe._
@@ -143,13 +143,13 @@ object InlineArray {
     c.Expr[U](tree)
   }
 
-  def foldLeftMacro[T, U](c: Context)(ts: c.Expr[TraversableOnce[T]], init: c.Expr[U])(fn: c.Expr[(U, T) => U]): c.Expr[U] =
+  def foldLeftMacro[T, U](c: Context)(ts: c.Expr[Array[T]], init: c.Expr[U])(fn: c.Expr[(U, T) => U]): c.Expr[U] =
     foldLeftTree(c)(ts.tree, init, fn)
 
   def foldLeftMethod[T, U](c: Context)(init: c.Expr[U])(fn: c.Expr[(U, T) => U]): c.Expr[U] =
     foldLeftTree(c)(singleConsArg(c), init, fn)
 
-  def reduceOption[T](ts: TraversableOnce[T])(fn: (T, T) => T): Option[T] = macro reduceOptionMacro[T]
+  def reduceOption[T](ts: Array[T])(fn: (T, T) => T): Option[T] = macro reduceOptionMacro[T]
 
   private[this] def reduceOptionTree[T](c: Context)(ts: c.Tree, fn: c.Expr[(T, T) => T]): c.Expr[Option[T]] = {
     import c.universe._
@@ -176,7 +176,7 @@ object InlineArray {
     c.Expr[Option[T]](tree)
   }
 
-  def reduceOptionMacro[T](c: Context)(ts: c.Expr[TraversableOnce[T]])(fn: c.Expr[(T, T) => T]): c.Expr[Option[T]] =
+  def reduceOptionMacro[T](c: Context)(ts: c.Expr[Array[T]])(fn: c.Expr[(T, T) => T]): c.Expr[Option[T]] =
     reduceOptionTree(c)(ts.tree, fn)
 
   def reduceOptionMethod[T](c: Context)(fn: c.Expr[(T, T) => T]): c.Expr[Option[T]] =

--- a/core/src/main/scala/com/github/johnynek/inliner/InlineRange.scala
+++ b/core/src/main/scala/com/github/johnynek/inliner/InlineRange.scala
@@ -1,0 +1,196 @@
+package com.github.johnynek.inliner
+
+import MacroCompat.{Context, newTerm, recurse, singleConsArg}
+import scala.collection.immutable.Range
+import scala.language.experimental.macros
+/**
+ * This class is never allocated because all the macros require
+ * them to be called as (new InlineOption(o).method) or it won't compile,
+ * if it compiles, that bit is replaced with code using if/else
+ */
+class InlineRange(o: Range) {
+  import InlineRange._
+
+  def find(fn: Int => Boolean): Option[Int] = macro findMethod
+  def forall(fn: Int => Boolean): Boolean = macro forallMethod
+  def foldLeft[U](init: U)(fn: (U, Int) => U): U = macro foldLeftMethod[U]
+  def foreach(fn: Int => Unit): Unit = macro foreachMethod
+  def reduceOption(fn: (Int, Int) => Int): Option[Int] = macro reduceOptionMethod
+}
+object InlineRange {
+  implicit class ToInlineRange(val o: Range) extends AnyVal {
+    @inline def inline: InlineRange = new InlineRange(o)
+  }
+
+  def find(ts: Range)(fn: Int => Boolean): Option[Int] = macro findMacro
+
+  private[this] def findTree(c: Context)(ts: c.Tree, fn: c.Expr[Int => Boolean]): c.Expr[Option[Int]] = {
+    import c.universe._
+    //println(showRaw(fn))
+    val (arg, newTree) = function1Apply(c)(fn)
+    //println(showRaw(newTree))
+    val end = newTerm(c, "end")
+    val pos = newTerm(c, "pos")
+    val step = newTerm(c, "step")
+    val res = newTerm(c, "res")
+    val rng = newTerm(c, "range")
+    val tree = q"""{
+      val $rng = $ts
+      var $res: _root_.scala.Option[Int] = _root_.scala.None
+      var $pos = $rng.start
+      val $end = $rng.end
+      val $step = $rng.step
+      while($pos < $end) {
+        val $arg = $pos
+        if($newTree) { $res = _root_.scala.Some($arg); $pos = $end }
+        $pos += $step
+      }
+      $res
+    }"""
+    //println(tree)
+    c.Expr[Option[Int]](tree)
+  }
+
+  def findMacro(c: Context)(ts: c.Expr[Range])(fn: c.Expr[Int => Boolean]): c.Expr[Option[Int]] =
+    findTree(c)(ts.tree, fn)
+
+  def findMethod(c: Context)(fn: c.Expr[Int => Boolean]): c.Expr[Option[Int]] =
+    findTree(c)(singleConsArg(c), fn)
+
+  def forall(ts: Range)(fn: Int => Boolean): Boolean = macro forallMacro
+
+  private[this] def forallTree[T](c: Context)(ts: c.Tree, fn: c.Expr[Int => Boolean]): c.Expr[Boolean] = {
+    import c.universe._
+    //println(showRaw(fn))
+    val (arg, newTree) = function1Apply(c)(fn)
+    //println(showRaw(newTree))
+    val end = newTerm(c, "end")
+    val pos = newTerm(c, "pos")
+    val step = newTerm(c, "step")
+    val res = newTerm(c, "res")
+    val rng = newTerm(c, "range")
+    val tree = q"""{
+      val $rng = $ts
+      var $res = true
+      var $pos = $rng.start
+      val $end = $rng.end
+      val $step = $rng.step
+      while($res && ($pos < $end)) {
+        val $arg = $pos
+        $res = $newTree
+        $pos += $step
+      }
+      $res
+    }"""
+    //println(tree)
+    c.Expr[Boolean](tree)
+  }
+  def forallMacro(c: Context)(ts: c.Expr[Range])(fn: c.Expr[Int => Boolean]): c.Expr[Boolean] =
+    forallTree(c)(ts.tree, fn)
+
+  def forallMethod(c: Context)(fn: c.Expr[Int => Boolean]): c.Expr[Boolean] =
+    forallTree(c)(singleConsArg(c), fn)
+
+  def foreach(ts: Range)(fn: Int => Unit): Unit = macro foreachMacro
+
+  private[this] def foreachTree(c: Context)(ts: c.Tree, fn: c.Expr[Int => Unit]): c.Expr[Unit] = {
+    import c.universe._
+    //println(showRaw(fn))
+    val (arg, newTree) = function1Apply(c)(fn)
+    //println(showRaw(newTree))
+    val end = newTerm(c, "end")
+    val pos = newTerm(c, "pos")
+    val step = newTerm(c, "step")
+    val rng = newTerm(c, "range")
+    val tree = q"""{
+      val $rng = $ts
+      var $pos = $rng.start
+      val $end = $rng.end
+      val $step = $rng.step
+      while($pos < $end) {
+        val $arg = $pos
+        $newTree
+        $pos += $step
+      }
+      ()
+    }"""
+    //println(tree)
+    c.Expr[Unit](tree)
+  }
+  def foreachMacro(c: Context)(ts: c.Expr[Range])(fn: c.Expr[Int => Unit]): c.Expr[Unit] =
+    foreachTree(c)(ts.tree, fn)
+
+  def foreachMethod(c: Context)(fn: c.Expr[Int => Unit]): c.Expr[Unit] =
+    foreachTree(c)(singleConsArg(c), fn)
+
+  def foldLeft[U](ts: Range, init: U)(fn: (U, Int) => U): U = macro foldLeftMacro[U]
+
+  private[this] def foldLeftTree[U](c: Context)(ts: c.Tree, init: c.Expr[U], fn: c.Expr[(U, Int) => U]): c.Expr[U] = {
+    import c.universe._
+    //println(showRaw(fn))
+    val (uarg, targ, newTree) = function2Apply(c)(fn)
+    val end = newTerm(c, "end")
+    val pos = newTerm(c, "pos")
+    val step = newTerm(c, "step")
+    val res = newTerm(c, "res")
+    val rng = newTerm(c, "range")
+    val tree = q"""{
+      val $rng = $ts
+      var $pos = $rng.start
+      val $end = $rng.end
+      var $uarg = $init
+      val $step = $rng.step
+      while($pos < $end) {
+        val $targ = $pos
+        $uarg = $newTree
+        $pos += $step
+      }
+      $uarg
+    }"""
+    //println(tree)
+    c.Expr[U](tree)
+  }
+
+  def foldLeftMacro[U](c: Context)(ts: c.Expr[Range], init: c.Expr[U])(fn: c.Expr[(U, Int) => U]): c.Expr[U] =
+    foldLeftTree(c)(ts.tree, init, fn)
+
+  def foldLeftMethod[U](c: Context)(init: c.Expr[U])(fn: c.Expr[(U, Int) => U]): c.Expr[U] =
+    foldLeftTree(c)(singleConsArg(c), init, fn)
+
+  def reduceOption(ts: Range)(fn: (Int, Int) => Int): Option[Int] = macro reduceOptionMacro
+
+  private[this] def reduceOptionTree(c: Context)(ts: c.Tree, fn: c.Expr[(Int, Int) => Int]): c.Expr[Option[Int]] = {
+    import c.universe._
+    //println(showRaw(fn))
+    val (uarg, targ, newTree) = function2Apply(c)(fn)
+    val end = newTerm(c, "end")
+    val pos = newTerm(c, "pos")
+    val step = newTerm(c, "step")
+    val res = newTerm(c, "res")
+    val rng = newTerm(c, "range")
+    val tree = q"""{
+      val $rng = $ts
+      var $pos = $rng.start
+      val $end = $rng.end
+      if ($pos >= $end) _root_.scala.None else {
+        var $uarg = $pos
+        val $step = $rng.step
+        $pos += $step
+        while($pos < $end) {
+          val $targ = $pos
+          $uarg = $newTree
+          $pos += $step
+        }
+        _root_.scala.Some($uarg)
+      }
+    }"""
+    //println(tree)
+    c.Expr[Option[Int]](tree)
+  }
+
+  def reduceOptionMacro(c: Context)(ts: c.Expr[Range])(fn: c.Expr[(Int, Int) => Int]): c.Expr[Option[Int]] =
+    reduceOptionTree(c)(ts.tree, fn)
+
+  def reduceOptionMethod(c: Context)(fn: c.Expr[(Int, Int) => Int]): c.Expr[Option[Int]] =
+    reduceOptionTree(c)(singleConsArg(c), fn)
+}

--- a/core/src/test/scala/com/github/johnynek/inliner/RangeTests.scala
+++ b/core/src/test/scala/com/github/johnynek/inliner/RangeTests.scala
@@ -1,0 +1,45 @@
+package com.github.johnynek.inliner
+
+import org.scalacheck._
+import Prop.forAll
+
+import scala.util.{Failure, Success, Try}
+
+object RangeTests extends Properties("Range") {
+
+  import InlineRange._
+  def rangeGen: Gen[Range] = for {
+    start <- Gen.chooseNum(-1000, 1000)
+    end <- Gen.chooseNum(start, 1000)
+    step <- Gen.chooseNum(1, math.max(1, end - start))
+  } yield new Range(start, end, step)
+
+  implicit def rangeArb: Arbitrary[Range] = Arbitrary(rangeGen)
+
+  property("inline.foreach works") = forAll { (l: Range) =>
+    var res = 0
+    l.inline.foreach { res += _ }
+
+    res == l.sum
+  }
+
+  property("inline.foldLeft works") = forAll { (l: Range) =>
+    l.inline.foldLeft(0)(_ + _) == l.sum
+  }
+  property("inline.foldLeft with case") = forAll { (l: Range) =>
+    l.inline.foldLeft(Option.empty[Int]) {
+      // This does not destructure into .isDefined calls (yet)
+      case (None, arg) => Some(arg)
+      case (Some(l), r) => Some(l + r)
+    } == l.reduceOption(_ + _)
+  }
+  property("inline.reduceOption works") = forAll { (l: Range) =>
+    l.inline.reduceOption(_ + _) == l.reduceOption(_ + _)
+  }
+  property("inline.find works") = forAll { (l: Range) =>
+    l.inline.find(_ % 42 == 41) == l.find(_ % 42 == 41)
+  }
+  property("inline.forall works") = forAll { (l: Range) =>
+    l.inline.forall(_ > 0) == l.forall(_ > 0)
+  }
+}


### PR DESCRIPTION
This is about 2x faster than using traversable once based approach since
we avoid the boxing:

[info] RangeBenchmarks.foreach          ss    8  2207427375.000 ± 49674933.949  ns/op
[info] RangeBenchmarks.foreachInline    ss    8  1114643000.000 ± 34562410.574  ns/op
